### PR TITLE
MPU6050 control implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@
 *.exe
 *.out
 *.app
+
+# Emacs
+*~
+#*#

--- a/lib/mpu6050/i2c_interface.cpp
+++ b/lib/mpu6050/i2c_interface.cpp
@@ -1,0 +1,65 @@
+/**
+  ******************************************************************************
+  * @file    i2c_interface.cpp
+  * @author  Ali Batuhan KINDAN
+  * @date    28.12.2020
+  * @brief   This file constains I2C Interface class implementation.
+  *
+  * MIT License
+  *
+  * Copyright (c) 2022 Ali Batuhan KINDAN
+  * 
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  * 
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  * 
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+#include "i2c_interface.h"
+
+/**
+  * @brief  This method will be used for reading a bit value of the given register
+  * from the slace device with the given address.
+  * @param  slaveAddress Slave chip I2C bus address
+  * @param  regAddress Register address that the data to be read
+  * @param  bitMask Bit mask to be read
+  * @param  status Pointer for operation status
+  * @retval bool Bit value
+  */
+bool I2C_Interface::ReadRegisterBit(uint8_t slaveAddress, uint8_t regAddress, uint8_t bitMask, i2c_status_t *status)
+{
+    return (ReadRegister(slaveAddress, regAddress, status) & bitMask);
+}
+
+  /**
+  * @brief  This method will be used for writing a bit value of the given register
+  * from the slace device with the given address.
+  * @param  slaveAddress Slave chip I2C bus address
+  * @param  regAddress Register address that the data to be written
+  * @param  bitNo Bit number to be set/reset
+  * @param  bitMask Bit mask to be set/reset
+  * @retval i2c_status_t
+  */
+i2c_status_t I2C_Interface::WriteRegisterBit(uint8_t slaveAddress, uint8_t regAddress, uint8_t bitMask, bool bitVal)
+{
+    i2c_status_t status = I2C_STATUS_NONE;
+    uint8_t data = ReadRegister(slaveAddress, regAddress, &status);
+    if(status == I2C_STATUS_SUCCESS)
+    {
+        status = WriteRegister(slaveAddress, regAddress, (data & ~bitMask) | (bitVal ? bitMask : 0x00));
+    }
+
+    return status;
+}

--- a/lib/mpu6050/i2c_interface.h
+++ b/lib/mpu6050/i2c_interface.h
@@ -1,0 +1,132 @@
+/**
+  ******************************************************************************
+  * @file    i2c_interface.h
+  * @author  Ali Batuhan KINDAN
+  * @date    28.12.2020
+  * @brief   This file constains I2C Interface class definition.
+  *
+  * MIT License
+  *
+  * Copyright (c) 2022 Ali Batuhan KINDAN
+  * 
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  * 
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  * 
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+#include <stdint.h>
+
+#ifndef I2C_INTERFACE_H
+#define I2C_INTERFACE_H
+
+/* I2C status types. 
+ * TODO: will be extended for different I2C error types! Keep it as enum for now. */
+enum i2c_status_t 
+{
+  I2C_STATUS_SUCCESS = 0x00,
+  I2C_STATUS_ERROR = 0x01,
+  I2C_STATUS_NONE = 0x02
+};
+
+/* I2C clock speed types */
+enum class i2c_clockspeed_t
+{
+  CLK_NONE = 0,
+  CLK_100KHz = 100000,
+  CLK_200KHz = 200000,
+  CLK_400KHz = 400000
+};
+
+/* I2C Interface class to make sensor driver work with
+ * other MCU architectures by simply overriding this virtual
+ * methods according to current architecture I2C driver methods. */
+class I2C_Interface
+{
+public:
+  /**
+  * @brief  Class constructor.
+  * @param  none
+  * @retval none
+  */
+  I2C_Interface() {/* empty constructor */};
+
+  /**
+  * @brief  Class destructor
+  * @param  none
+  * @retval none
+  */
+  virtual ~I2C_Interface() {/* empty virtual destructor */};
+
+  /* TODO: Init_I2C methods should be differenciated by compiler without the need of casting! */
+
+  /**
+  * @brief  I2C peripheral initialization method.
+  * @param  clock I2C clock frequency (default 100 kHz)
+  * @retval i2c_status_t
+  */
+  virtual i2c_status_t Init_I2C(i2c_clockspeed_t clock = i2c_clockspeed_t::CLK_100KHz) {return I2C_STATUS_NONE;};
+
+  /**
+  * @brief  I2C peripheral initialization method.
+  * @param  slaveAddress adress of the device that will be communicated
+  * @retval i2c_status_t
+  */
+  virtual i2c_status_t Init_I2C(uint8_t slaveAddress) {return I2C_STATUS_NONE;};
+
+  /**
+  * @brief  This method will be used for reading the data of the given register from
+  * the slave with given address.
+  * @param  slaveAddress Slave chip I2C bus address
+  * @param  regAddress Register address to be read
+  * @param  status Pointer for operation status
+  * @retval uint8_t Read register value
+  */
+  virtual uint8_t ReadRegister(uint8_t slaveAddress, uint8_t regAddress, i2c_status_t *status) = 0;
+
+  /**
+  * @brief  This method will be used for writing gven data to the given register of the slave device 
+  * with the given address.
+  * @param  slaveAddress Slave chip I2C bus address
+  * @param  regAddress Register address that the data to be written
+  * @param  data Data to be written
+  * @retval i2c_status_t
+  */
+  virtual i2c_status_t WriteRegister(uint8_t slaveAddress, uint8_t regAddress, uint8_t data) = 0;
+
+  /**
+  * @brief  This method will be used for reading a bit value of the given register
+  * from the slace device with the given address.
+  * @param  slaveAddress Slave chip I2C bus address
+  * @param  regAddress Register address that the data to be read
+  * @param  bitMask Bit mask to be read
+  * @param  status Pointer for operation status
+  * @retval bool Bit value
+  */
+  bool ReadRegisterBit(uint8_t slaveAddress, uint8_t regAddress, uint8_t bitMask, i2c_status_t *status);
+
+  /**
+  * @brief  This method will be used for writing a bit value of the given register
+  * from the slace device with the given address.
+  * @param  slaveAddress Slave chip I2C bus address
+  * @param  regAddress Register address that the data to be written
+  * @param  bitMask Bit mask to be set/reset
+  * @param  bitVal Bit value to be written
+  * @retval i2c_status_t
+  */
+  i2c_status_t WriteRegisterBit(uint8_t slaveAddress, uint8_t regAddress, uint8_t bitMask, bool bitVal);
+};
+
+#endif /* include guard */

--- a/lib/mpu6050/mpu6050.cpp
+++ b/lib/mpu6050/mpu6050.cpp
@@ -1,0 +1,1039 @@
+/**
+  ******************************************************************************
+  * @file    mpu6050.cpp
+  * @author  Ali Batuhan KINDAN
+  * @date    20.12.2020
+  * @brief   This file constains MPU6050 driver implementation.
+  *
+  * MIT License
+  *
+  * Copyright (c) 2022 Ali Batuhan KINDAN
+  * 
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  * 
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  * 
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+#include "mpu6050.h"
+
+namespace MPU6050_Driver {
+
+  /**
+    * @brief  Class constructor. In order to make the class communicate with sensor
+    * user should pass a valid I2C_Interface class instance!
+    * @param  comInterface I2C interface pointer
+    * @retval none
+    */
+  MPU6050::MPU6050(I2C_Interface *comInterface)
+  {
+    /* assign internal interface pointer if given is not null! */
+    if (comInterface)
+    {
+      this->i2c = comInterface;
+    }
+  }
+
+  /**
+    * @brief  This method wakes up the sensor and configures the accelerometer and
+    * gyroscope full scale renges with given parameters. It returns the result of
+    * the process.
+    * @param  gyroScale Gyroscope scale value to be set
+    * @param  accelScale Accelerometer scale value to be set
+    * @retval i2c_status_t Success rate
+    */
+  i2c_status_t MPU6050::InitializeSensor(
+      Gyro_FS_t gyroScale,
+      Accel_FS_t accelScale)
+  {
+    i2c_status_t result = WakeUpSensor();
+    if(result == I2C_STATUS_SUCCESS)
+      result = SetGyroFullScale(gyroScale);
+    if(result == I2C_STATUS_SUCCESS)
+      result = SetAccelFullScale(accelScale);
+
+    return result;
+  }
+
+  /**
+    * @brief  This method wakes the sensor up by cleraing the MPU6050_Regs::PWR_MGMT_1
+    * BIT_SLEEP. Power management 1 sensors default values is 0x40 so it will
+    * be in sleep mode when it's powered up.
+    * @param  none
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::WakeUpSensor(void)
+  {
+    return i2c->WriteRegisterBit(MPU6050_ADDRESS, Sensor_Regs::PWR_MGMT_1, Regbits_PWR_MGMT_1::BIT_SLEEP, false);
+  }
+
+  /**
+    * @brief  This method resets the sensor by simply setting the MPU6050_Regs::PWR_MGMT_1
+    * Device_Reset bit. After the sensor reset this bit will be cleared automatically.
+    * TODO: Can be modify later to check the Device_Reset bit is clear after the reset
+    * in order to make it safer (for this we probably need an interface for platform
+    * delay function).
+    * @param  none
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::ResetSensor(void)
+  {
+    return i2c->WriteRegisterBit(MPU6050_ADDRESS, Sensor_Regs::PWR_MGMT_1, Regbits_PWR_MGMT_1::BIT_DEVICE_RESET, true);
+  }
+
+  /**
+    * @brief  This method used for configuring the gyroscope full scale range.
+    * Check gyro_full_scale_range_t for available scales.
+    * @param  gyroScale Gyroscope scale value to be set
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::SetGyroFullScale(Gyro_FS_t gyroScale)
+  {
+    return i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::GYRO_CONFIG, ((uint8_t)gyroScale << 3));
+  }
+
+  /**
+    * @brief  This method used for getting the gyroscope full scale range.
+    * Check gyro_full_scale_range_t for available scales. It basically reads the
+    * Gyro configuration register and returns the full scale range.
+    * @param  error Result of the sensor reading process
+    * @retval gyro_full_scale_range_t
+    */
+  Gyro_FS_t MPU6050::GetGyroFullScale(i2c_status_t *error)
+  {
+    uint8_t gyroConfig = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::GYRO_CONFIG, error);
+    return (Gyro_FS_t)((gyroConfig >> 3) & 0x03);
+  }
+
+  /**
+    * @brief  This method used for getting the latest gyroscope X axis RAW value from
+    * the sensor. Make sure that sensor is not in sleeping mode and gyroscope full
+    * scale range is set to desired range before reading the values.
+    * @param  error Error state of process
+    * @retval int16_t X axis RAW gyroscope value
+    */
+  int16_t MPU6050::GetGyro_X_Raw(i2c_status_t *error)
+  {
+    int16_t gyroXVal = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::GYRO_X_OUT_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      gyroXVal = (gyroXVal << 8) | i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::GYRO_X_OUT_L, error); // assemble higher and lower bytes
+      return gyroXVal;
+    }
+
+    return 0x00; 
+  }
+
+  /**
+    * @brief  This method used for getting the latest gyroscope Y axis RAW value from
+    * the sensor. Make sure that sensor is not in sleeping mode and gyroscope full
+    * scale range is set to desired range before reading the values.
+    * @param  error Error state of process
+    * @retval int16_t Y axis RAW gyroscope value
+    */
+  int16_t MPU6050::GetGyro_Y_Raw(i2c_status_t *error)
+  {
+    int16_t gyroYVal = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::GYRO_Y_OUT_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      gyroYVal = (gyroYVal << 8) | i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::GYRO_Y_OUT_L, error); // assemble higher and lower bytes
+      return gyroYVal;
+    }
+
+    return 0x00;  
+  }
+
+  /**
+    * @brief  This method used for getting the latest gyroscope Z axis RAW value from
+    * the sensor. Make sure that sensor is not in sleeping mode and gyroscope full
+    * scale range is set to desired range before reading the values.
+    * @param  error Error state of process
+    * @retval int16_t Z axis RAW gyroscope value
+    */
+  int16_t MPU6050::GetGyro_Z_Raw(i2c_status_t *error)
+  {
+    int16_t gyroZVal = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::GYRO_Z_OUT_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      gyroZVal = (gyroZVal << 8) | i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::GYRO_Z_OUT_L, error); // assemble higher and lower bytes
+      return gyroZVal;
+    }
+
+    return 0x00;
+  }
+
+  /**
+    * @brief  This method used for configuring the accelerometer full scale range.
+    * Check accel_full_scale_range_t for available scales.
+    * @param  accelScale Accelerometer scale value to be set
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::SetAccelFullScale(Accel_FS_t accelScale)
+  {
+    return i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::ACCEL_CONFIG, ((uint8_t)accelScale << 3));
+  }
+
+  /**
+    * @brief  This method used for getting the acceleromteter full scale range.
+    * Check accel_full_scale_range_t for available scales. It basically reads the
+    * Accel configuration register and returns the full scale range.
+    * @param  error Result of the sensor reading process
+    * @retval accel_full_scale_range_t
+    */
+  Accel_FS_t MPU6050::GetAccelFullScale(i2c_status_t *error)
+  {
+    uint8_t accelConfig = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::ACCEL_CONFIG, error);
+    return (Accel_FS_t)((accelConfig >> 3) & 0x03);  
+  }
+
+  /**
+    * @brief  This method used for getting the latest accelerometer X axis RAW value from
+    * the sensor. Make sure that sensor is not in sleeping mode and accelerometer full
+    * scale range is set to desired range, before reading the values.
+    * @param  error Error state of process
+    * @retval int16_t X axis RAW acceleration value
+    */
+  int16_t MPU6050::GetAccel_X_Raw(i2c_status_t *error)
+  {
+    int16_t accelXVal = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::ACCEL_X_OUT_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      accelXVal = (accelXVal << 8) | i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::ACCEL_X_OUT_L, error); // assemble higher and lower bytes
+      return accelXVal;
+    }
+
+    return 0x00;
+  }
+
+  /**
+    * @brief  This method used for getting the latest accelerometer Y axis RAW value from
+    * the sensor. Make sure that sensor is not in sleeping mode and accelerometer full
+    * scale range is set to desired range, before reading the values.
+    * @param  error Error state of process
+    * @retval int16_t Y axis RAW acceleration value
+    */
+  int16_t MPU6050::GetAccel_Y_Raw(i2c_status_t *error)
+  {
+    int16_t accelYVal = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::ACCEL_Y_OUT_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      accelYVal = (accelYVal << 8) | i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::ACCEL_Y_OUT_L, error); // assemble higher and lower bytes
+      return accelYVal;
+    }
+
+    return 0x00;
+  }
+
+  /**
+    * @brief  This method used for getting the latest accelerometer Z axis RAW value from
+    * the sensor. Make sure that sensor is not in sleeping mode and accelerometer full
+    * scale range is set to desired range, before reading the values.
+    * @param  error Error state of process
+    * @retval int16_t Z axis RAW acceleration value
+    */
+  int16_t MPU6050::GetAccel_Z_Raw(i2c_status_t *error)
+  {
+    int16_t accelZVal = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::ACCEL_Z_OUT_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      accelZVal = (accelZVal << 8) | i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::ACCEL_Z_OUT_L, error); // assemble higher and lower bytes
+      return accelZVal;
+    }
+
+    return 0x00;
+  }
+
+  /**
+    * @brief  This method used for getting the latest temperature value from the sensor.
+    * scale range is set to desired range, before reading the values.
+    * @param  error Error state of process
+    * @retval float Temperature in celcius-degrees
+    */
+  float MPU6050::GetTemperature_Celcius(i2c_status_t *error)
+  {
+    int16_t sensorTemp = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::TEMP_OUT_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      sensorTemp = (sensorTemp << 8) |  i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::TEMP_OUT_L, error); // assemble higher and lower bytes
+      return (sensorTemp / 340.0 + 36.53f);
+    }
+
+    return 0x00;
+  }
+
+  /**
+    * @brief  This method used for setting the gyroscope X axis offset value. Offset is
+    * using in the sensor calibration routine.
+    * @param offset
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::SetGyro_X_Offset(int16_t offset)
+  {
+    i2c_status_t result = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::XG_OFFS_USR_H, (offset >> 8));
+    if(result == I2C_STATUS_SUCCESS)
+    {
+      result = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::XG_OFFS_USR_L, (offset & 0x00FF));
+    }
+    return result;
+  }
+
+  /**
+    * @brief  This method used for getting the gyroscope X axis offset value.
+    * @param error Result of the operation
+    * @retval int16_t
+    */
+  int16_t MPU6050::GetGyro_X_Offset(i2c_status_t *error)
+  {
+    int16_t gyroXOffset = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::XG_OFFS_USR_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      gyroXOffset = (gyroXOffset << 8) |  i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::XG_OFFS_USR_L, error); // assemble higher and lower bytes
+      return gyroXOffset;
+    }
+
+    return 0x00;
+  }
+
+  /**
+    * @brief  This method used for setting the gyroscope Y axis offset value. Offset is
+    * using in the sensor calibration routine.
+    * @param offset
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::SetGyro_Y_Offset(int16_t offset)
+  {
+    i2c_status_t result = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::YG_OFFS_USR_H, (offset >> 8));
+    if(result == I2C_STATUS_SUCCESS)
+    {
+      result = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::YG_OFFS_USR_L, (offset & 0x00FF));
+    }
+    return result;
+  }
+
+  /**
+    * @brief  This method used for getting the gyroscope Y axis offset value.
+    * @param error Result of the operation
+    * @retval int16_t
+    */
+  int16_t MPU6050::GetGyro_Y_Offset(i2c_status_t *error)
+  {
+    int16_t gyroYOffset = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::YG_OFFS_USR_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      gyroYOffset = (gyroYOffset << 8) |  i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::YG_OFFS_USR_L, error); // assemble higher and lower bytes
+      return gyroYOffset;
+    }
+
+    return 0x00;
+  }
+
+  /**
+    * @brief  This method used for setting the gyroscope Z axis offset value. Offset is
+    * using in the sensor calibration routine.
+    * @param offset
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::SetGyro_Z_Offset(int16_t offset)
+  {
+    i2c_status_t result = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::ZG_OFFS_USR_H, (offset >> 8));
+    if(result == I2C_STATUS_SUCCESS)
+    {
+      result = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::ZG_OFFS_USR_L, (offset & 0x00FF));
+    }
+    return result;
+  }
+
+  /**
+    * @brief  This method used for getting the gyroscope Z axis offset value.
+    * @param error Result of the operation
+    * @retval int16_t
+    */
+  int16_t MPU6050::GetGyro_Z_Offset(i2c_status_t *error)
+  {
+    int16_t gyroZOffset = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::ZG_OFFS_USR_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      gyroZOffset = (gyroZOffset << 8) |  i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::ZG_OFFS_USR_L, error); // assemble higher and lower bytes
+      return gyroZOffset;
+    }
+
+    return 0x00;
+  }
+
+  /**
+    * @brief  This method used for calibrating the gyroscope registers to given target values.
+    * Its VERY important to mention that when you call this method make sure that the sensor is
+    * standing statically (no vibrations, no rotations, no movement etc.) otherwise you will end
+    * up with wrong calibration values!
+    * TODO: Use more detailed return type about the calibration status to inform user about the
+    * failure (which step it failed and why etc.).
+    * @param targetX target value for gyroscope X axis register
+    * @param targetY target value for gyroscope Y axis register
+    * @param targetZ target value for gyroscope Z axis register
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::Calibrate_Gyro_Registers(int16_t targetX, int16_t targetY, int16_t targetZ)
+  {
+    i2c_status_t result = I2C_STATUS_NONE;
+    Gyro_FS_t gyroRange = GetGyroFullScale(&result);
+    if(result != I2C_STATUS_SUCCESS)
+      return result;
+
+    /* DPS constant to convert raw register value to the 
+    * degree per seconds (angular velocity). */
+    const float dpsConstant = dpsConstantArr[static_cast<uint8_t>(gyroRange)];
+    float sumOfSamples = 0;
+    int16_t offsetVal = 0;
+
+    /*
+    * Gyro X axis calibration
+    */
+    for(uint16_t i = 0; i < 1000 && result == I2C_STATUS_SUCCESS; i++)
+    {
+      sumOfSamples += GetGyro_X_Raw(&result);
+    }
+    sumOfSamples *= 0.001f; // get mean value of 1000 readings
+
+    if(result != I2C_STATUS_SUCCESS)
+      return result;
+
+    offsetVal = (int16_t)(((targetX - sumOfSamples) * dpsConstant) * gyro_offset_1dps);
+    result = SetGyro_X_Offset(offsetVal);
+
+    if(result != I2C_STATUS_SUCCESS)
+      return result;
+
+    /*
+    * Gyro Y axis calibration
+    */
+    sumOfSamples = 0;
+    for(uint16_t i = 0; i < 1000 && result == I2C_STATUS_SUCCESS; i++)
+    {
+      sumOfSamples += GetGyro_Y_Raw(&result);
+    }
+    sumOfSamples *= 0.001f; // get mean value of 1000 readings
+
+    if(result != I2C_STATUS_SUCCESS)
+      return result;
+
+    offsetVal = (int16_t)(((targetY - sumOfSamples) * dpsConstant) * gyro_offset_1dps);
+    result = SetGyro_Y_Offset(offsetVal);
+
+    if(result != I2C_STATUS_SUCCESS)
+      return result;
+
+    /*
+    * Gyro Z axis calibration
+    */
+    sumOfSamples = 0;
+    for(uint16_t i = 0; i < 1000 && result == I2C_STATUS_SUCCESS; i++)
+    {
+      sumOfSamples += GetGyro_Z_Raw(&result);
+    }
+    sumOfSamples *= 0.001f; // get mean value of 1000 readings
+
+    if(result != I2C_STATUS_SUCCESS)
+      return result;
+
+    offsetVal = (int16_t)(((targetZ - sumOfSamples) * dpsConstant) * gyro_offset_1dps);
+    result = SetGyro_Z_Offset(offsetVal);
+
+    return result;
+  }
+
+  /**
+    * @brief  This method returns the DPS (Degree Per Second) coversion value depending on
+    * the gyroscope full scale range. DPS value is used to convert raw sensor value to angular
+    * velocity for orientation related calculations.
+    * @param gyroRange Configured gyro full scale range
+    * @retval float
+    */
+  float MPU6050::GetGyro_DPS_Constant(Gyro_FS_t gyroRange)
+  {
+    return dpsConstantArr[static_cast<uint8_t>(gyroRange)];
+  }
+
+  /**
+    * @brief  This method used for setting the accelerometer X axis offset value. Offset is
+    * using in the sensor calibration routine.
+    * @param offset
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::SetAccel_X_Offset(int16_t offset)
+  {
+    i2c_status_t result = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::XA_OFFS_USR_H, (offset >> 8));
+    if(result == I2C_STATUS_SUCCESS)
+    {
+      result = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::XA_OFFS_USR_L, (offset & 0x00FF));
+    }
+    return result;   
+  }
+
+  /**
+    * @brief  This method used for getting the accelerometer X axis offset value.
+    * @param error Result of the operation
+    * @retval int16_t
+    */
+  int16_t MPU6050::GetAccel_X_Offset(i2c_status_t *error)
+  {
+    int16_t accelXOffset = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::XA_OFFS_USR_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      accelXOffset = (accelXOffset << 8) |  i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::XA_OFFS_USR_L, error); // assemble higher and lower bytes
+      return accelXOffset;
+    }
+
+    return 0x00;
+  }
+
+  /**
+    * @brief  This method used for setting the accelerometer Y axis offset value. Offset is
+    * using in the sensor calibration routine.
+    * @param offset
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::SetAccel_Y_Offset(int16_t offset)
+  {
+    i2c_status_t result = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::YA_OFFS_USR_H, (offset >> 8));
+    if(result == I2C_STATUS_SUCCESS)
+    {
+      result = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::YA_OFFS_USR_L, (offset & 0x00FF));
+    }
+    return result;  
+  }
+
+  /**
+    * @brief  This method used for getting the accelerometer Y axis offset value.
+    * @param error Result of the operation
+    * @retval int16_t
+    */
+  int16_t MPU6050::GetAccel_Y_Offset(i2c_status_t *error)
+  {
+    int16_t accelYOffset = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::YA_OFFS_USR_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      accelYOffset = (accelYOffset << 8) |  i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::YA_OFFS_USR_L, error); // assemble higher and lower bytes
+      return accelYOffset;
+    }
+
+    return 0x00; 
+  }
+
+  /**
+    * @brief  This method used for setting the accelerometer Z axis offset value. Offset is
+    * using in the sensor calibration routine.
+    * @param offset
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::SetAccel_Z_Offset(int16_t offset)
+  {
+    i2c_status_t result = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::ZA_OFFS_USR_H, (offset >> 8));
+    if(result == I2C_STATUS_SUCCESS)
+    {
+      result = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::ZA_OFFS_USR_L, (offset & 0x00FF));
+    }
+    return result;  
+  }
+
+  /**
+    * @brief  This method used for getting the accelerometer Z axis offset value.
+    * @param error Result of the operation
+    * @retval int16_t
+    */
+  int16_t MPU6050::GetAccel_Z_Offset(i2c_status_t *error)
+  {
+    int16_t accelZOffset = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::ZA_OFFS_USR_H, error); // higher 8 bits
+    if(*error == I2C_STATUS_SUCCESS)
+    {
+      accelZOffset = (accelZOffset << 8) |  i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::ZA_OFFS_USR_L, error); // assemble higher and lower bytes
+      return accelZOffset;
+    }
+
+    return 0x00;   
+  }
+
+  /**
+    * @brief  This method used for calibrating the accelerometer registers to given target values. Even if
+    * the official calibration method in the invensense application notes are tried, it didnt work as expected.
+    * So there is another method implemented to calibrate accelerometer registers automatically. It works with the
+    * similar concept of binary search algorithm (setting a range and narrowing on each step).
+    * @param targetX target value for accelerometer X axis register in MG so 1.0f means 1G
+    * @param targetY target value for accelerometer Y axis register in MG
+    * @param targetZ target value for accelerometer Z axis register in MG
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::Calibrate_Accel_Registers(float targetX_MG, float targetY_MG, float targetZ_MG)
+  {
+    i2c_status_t result = I2C_STATUS_NONE;
+    Accel_FS_t accelRange = GetAccelFullScale(&result);
+    if(result != I2C_STATUS_SUCCESS)
+      return result;
+
+    /* MG constant to convert raw register value to the 
+    * gravity (9.81 m/s2). */
+    const float mgConstant = mgCostantArr[static_cast<uint8_t>(accelRange)];
+
+    /* Some constants for our calibration routine to modify easily when needed. */
+    const int16_t calibrationRangeHigh = 4096;
+    const int16_t calibrationRangeLow = -calibrationRangeHigh;
+    const uint8_t calibrationSteps = 13; // if the calibrationRangeHigh = 2^n so this will be (n +1)
+    const int tolerance = 5; // acceptable tolerance between target and mean value of samples
+
+    float meanOfNSamples = 0;
+    int16_t regExpected = 0;
+    int16_t diff = 0;
+    int16_t high = calibrationRangeHigh;
+    int16_t low = calibrationRangeLow;
+    int16_t currentOffsetVal = 0;
+
+    result = SetAccel_X_Offset(0); // set the offset to 0 first
+
+    if(result != I2C_STATUS_SUCCESS)
+      return result;
+
+    result = SetAccel_Y_Offset(0); // set the offset to 0 first
+
+    if(result != I2C_STATUS_SUCCESS)
+      return result;
+
+    result = SetAccel_Z_Offset(0); // set the offset to 0 first
+
+    if(result != I2C_STATUS_SUCCESS)
+      return result;
+
+    /*
+    * Accel X axis calibration
+    */
+    regExpected = targetX_MG / mgConstant;
+
+    /* Get the initial deviation from our target value after reseting the offset register */
+    meanOfNSamples = 0;
+    for (uint8_t i = 0; i < 100 && result == I2C_STATUS_SUCCESS; i++)
+    {
+      meanOfNSamples += GetAccel_X_Raw(&result);
+    }
+
+    if(result != I2C_STATUS_SUCCESS)
+      return result;
+
+    meanOfNSamples *= 0.01;
+    diff = regExpected - meanOfNSamples;
+
+    /* Limit our ranges depending on the initial results. So we
+    * are either work on negative or positive range during the 
+    * calibration steps. */
+    if (diff < 0)
+      high = 0;
+    else
+      low = 0;
+
+    /* Start N steps of calibration. This method is very similar to binary search
+    * algorightm in sorted list. On every iteration we are setting the offset register
+    * to a middle value of our high and low range then we read 100 samples from 
+    * Accelerometer and compare our target and mean value of the samples. Depending on the
+    * result we are narrowing our high and low limits and repeat... */
+    for (uint8_t step = 0; step < calibrationSteps; step++)
+    {
+      /* Update offset register! */
+      currentOffsetVal = (int16_t)((high + low) /2.0f);
+      result = SetAccel_X_Offset(currentOffsetVal);
+      if (result != I2C_STATUS_SUCCESS)
+        return result;
+
+      /* Take 100 samples and compare with target */
+      meanOfNSamples = 0;
+      for (uint8_t i = 0; i < 100 && result == I2C_STATUS_SUCCESS; i++)
+      {
+        meanOfNSamples += GetAccel_X_Raw(&result);
+      }
+
+      if (result != I2C_STATUS_SUCCESS)
+        return result;
+
+      meanOfNSamples *= 0.01;
+      diff = regExpected - meanOfNSamples;
+
+      /* Quick math.abs to check if difference is in tolerance level.
+      * If yes abort calibration for this axis its done already! */
+      if((diff & 0x8000 ? -diff : diff) < tolerance)
+        break;
+
+      /* Update ranges! */
+      if(diff < 0)
+        high = currentOffsetVal;
+      else
+        low = currentOffsetVal;
+    } // for calibrationSteps
+
+    /*
+    * Accel Y axis calibration (TODO: unfortunately bad practice of code reusing but keep it for now!)
+    */
+    high = calibrationRangeHigh;
+    low = calibrationRangeLow;
+    currentOffsetVal = 0;
+
+    regExpected = targetY_MG / mgConstant;
+
+    /* Get the initial deviation from our target value after reseting the offset register */
+    meanOfNSamples = 0;
+    for (uint8_t i = 0; i < 100 && result == I2C_STATUS_SUCCESS; i++)
+    {
+      meanOfNSamples += GetAccel_Y_Raw(&result);
+    }
+
+    if (result != I2C_STATUS_SUCCESS)
+      return result;
+
+    meanOfNSamples *= 0.01;
+    diff = regExpected - meanOfNSamples;
+
+    /* Limit our ranges depending on the initial results. So we
+    * are either work on negative or positive range during the 
+    * calibration steps. */
+    if (diff < 0)
+      high = 0;
+    else
+      low = 0;
+
+    /* Start N steps of calibration. This method is very similar to binary search
+    * algorightm in sorted list. On every iteration we are setting the offset register
+    * to a middle value of our high and low range then we read 100 samples from 
+    * Accelerometer and compare our target and mean value of the samples. Depending on the
+    * result we are narrowing our high and low limits and repeat... */
+    for (uint8_t step = 0; step < calibrationSteps; step++)
+    {
+      /* Update offset register! */
+      currentOffsetVal = (int16_t)((high + low) /2.0f);
+      result = SetAccel_Y_Offset(currentOffsetVal);
+      if (result != I2C_STATUS_SUCCESS)
+        return result;
+
+      /* Take 100 samples and compare with target */
+      meanOfNSamples = 0;
+      for (uint8_t i = 0; i < 100 && result == I2C_STATUS_SUCCESS; i++)
+      {
+        meanOfNSamples += GetAccel_Y_Raw(&result);
+      }
+
+      if (result != I2C_STATUS_SUCCESS)
+        return result;
+
+      meanOfNSamples *= 0.01;
+      diff = regExpected - meanOfNSamples;
+
+      /* Quick math.abs to check if difference is in tolerance level.
+      * If yes abort calibration for this axis its done already! */
+      if((diff & 0x8000 ? -diff : diff) < tolerance)
+        break;
+
+      /* Update ranges! */
+      if(diff < 0)
+        high = currentOffsetVal;
+      else
+        low = currentOffsetVal;
+    } // for calibrationSteps
+
+    /*
+    * Accel Z axis calibration (TODO: unfortunately bad practice of code reusing but keep it for now!)
+    */
+    high = calibrationRangeHigh;
+    low = calibrationRangeLow;
+    currentOffsetVal = 0;
+
+    regExpected = targetZ_MG / mgConstant;
+
+    /* Get the initial deviation from our target value after reseting the offset register */
+    meanOfNSamples = 0;
+    for (uint8_t i = 0; i < 100 && result == I2C_STATUS_SUCCESS; i++)
+    {
+      meanOfNSamples += GetAccel_Z_Raw(&result);
+    }
+
+    if (result != I2C_STATUS_SUCCESS)
+      return result;
+
+    meanOfNSamples *= 0.01;
+    diff = regExpected - meanOfNSamples;
+
+    /* Limit our ranges depending on the initial results. So we
+    * are either work on negative or positive range during the 
+    * calibration steps. */
+    if (diff < 0)
+      high = 0;
+    else
+      low = 0;
+
+    /* Start N steps of calibration. This method is very similar to binary search
+    * algorightm in sorted list. On every iteration we are setting the offset register
+    * to a middle value of our high and low range then we read 100 samples from 
+    * Accelerometer and compare our target and mean value of the samples. Depending on the
+    * result we are narrowing our high and low limits and repeat... */
+    for (uint8_t step = 0; step < calibrationSteps; step++)
+    {
+      /* Update offset register! */
+      currentOffsetVal = (int16_t)((high + low) /2.0f);
+      result = SetAccel_Z_Offset(currentOffsetVal);
+      if (result != I2C_STATUS_SUCCESS)
+        return result;
+
+      /* Take 100 samples and compare with target */
+      meanOfNSamples = 0;
+      for (uint8_t i = 0; i < 100 && result == I2C_STATUS_SUCCESS; i++)
+      {
+        meanOfNSamples += GetAccel_Z_Raw(&result);
+      }
+
+      if (result != I2C_STATUS_SUCCESS)
+        return result;
+
+      meanOfNSamples *= 0.01;
+      diff = regExpected - meanOfNSamples;
+
+      /* Quick math.abs to check if difference is in tolerance level.
+      * If yes abort calibration for this axis its done already! */
+      if((diff & 0x8000 ? -diff : diff) < tolerance)
+        break;
+
+      /* Update ranges! */
+      if(diff < 0)
+        high = currentOffsetVal;
+      else
+        low = currentOffsetVal;
+    } // for calibrationSteps
+
+    return result;
+  }
+
+  /**
+    * @brief  This method returns the MG (Gravity) coversion value depending on
+    * the accelerometer full scale range. MG value is used to convert raw sensor value to Gravity
+    * for acceleration related calculations.
+    * @param accelRange Configured accelerometer full scale range
+    * @retval float
+    */
+  float MPU6050::GetAccel_MG_Constant(Accel_FS_t accelRange)
+  {
+    return mgCostantArr[static_cast<uint8_t>(accelRange)];
+  }
+
+  /**
+    * @brief This function sets the gyroscope sample rate divider. Once the sample rate divider set, actual sample rate
+    *        can be found with this formula:
+    *        Actual sample rate = Gyroscope Output Rate / (1 + sampleRate)
+    *        Keep in mind that Gyroscope Output Rate = 8kHz when the DLPF (digital low pass filter) is disabled
+    *        (DLPF_CFG = 0 or 7), and 1kHz when the DLPF is enabled. Accel sample rate is constantly 1 kHz.
+    * @param sampleRate Gyroscope sample rate divider value
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::SetGyro_SampleRateDivider(uint8_t sampleRate)
+  {
+    return i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::SMPRT_DIV, sampleRate);
+  }
+
+  /**
+    * @brief This function gets the gyroscope sample rate divider.
+    *        Actual sample rate = Gyroscope Output Rate / (1 + sampleRate)
+    *        Keep in mind that Gyroscope Output Rate = 8kHz when the DLPF (digital low pass filter) is disabled
+    *        (DLPF_CFG = 0 or 7), and 1kHz when the DLPF is enabled. Accel sample rate is constantly 1 kHz.
+    * @param error Result of the operation
+    * @retval uint8_t
+    */
+  uint8_t MPU6050::GetGyro_SampleRateDivider(i2c_status_t *error)
+  {
+    return i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::SMPRT_DIV, error);
+  }
+
+  /**
+    * @brief This function sets the sensor digital low pass filter values. Tighter bandwitdh configs will
+    *        generate more delay on the sensor outputs (check sensor datasheet). Keep in mind that default
+    *        Gyroscope sample rate is 8 kHz but if we set DLPF config different than 0 it will be 1 kHz by default
+    *        unless if we make an extra configuration to Sample Rate Divider.
+    * @param dlpfConfig Digital low pass filter configuration value
+    * @retval i2c_status_t
+    */
+  i2c_status_t MPU6050::SetSensor_DLPF_Config(DLPF_t dlpfConfig)
+  {
+    i2c_status_t error = I2C_STATUS_NONE;
+    /* This register also have EXT_SYNC config, so only set the DLPF part! */
+    uint8_t currentRegVal = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::CONFIG, &error);
+    if (error == I2C_STATUS_SUCCESS) {
+      currentRegVal &= (~0x07); // clear the DLPF section from the current register value
+      error = i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::CONFIG, (uint8_t)dlpfConfig | currentRegVal);
+    }
+    
+    return error;
+  }
+
+  /**
+    * @brief This function gets the current sensor digital low pass filter configuration.
+    * @param error Result of the operation
+    * @retval dlpf_config_t
+    */
+  DLPF_t MPU6050::GetSensor_DLPF_Config(i2c_status_t *error)
+  {
+    /* get only the first 3 bit of the register */
+    return (DLPF_t) (i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::CONFIG, error) & 0x07);
+  }
+
+  /**
+    * @brief This function gets the current sensor sample rate. In order to do this, method
+    *        reads Sample Rate Divider (0x19) and DLPF Config (0x1A) registers.
+    * @param error Result of the operation
+    * @retval float Current sample rate in Hz
+    */
+  float MPU6050::GetSensor_CurrentSampleRate_Hz(i2c_status_t *error)
+  {
+    uint8_t sampleRateDivider = GetGyro_SampleRateDivider(error);
+    if(*error != I2C_STATUS_SUCCESS)
+      return 0x00;
+
+    const uint8_t dlpfConfig = static_cast<uint8_t>(GetSensor_DLPF_Config(error));
+    if(*error != I2C_STATUS_SUCCESS)
+      return 0x00;
+    
+    /* if dlpf config is disabled (0 or 7) then sample rate is 8 kHz otherwise 1 kHz */
+    const float gyroDefaultOutRateHz = (dlpfConfig == static_cast<uint8_t>(DLPF_t::BW_260Hz) || dlpfConfig == static_cast<uint8_t>(DLPF_t::RESERVED)) ? 8000 : 1000;
+    return gyroDefaultOutRateHz / (1 + sampleRateDivider);
+  }
+
+    /**
+    * @brief This function gets the number of bytes written in the sensor FIFO buffers.
+    * @param error Result of the operation
+    * @retval uint16_t Number of samples in the FIFO buffer in bytes
+    */
+    uint16_t MPU6050::GetSensor_FIFOCount(i2c_status_t* error)
+    {
+      uint16_t fifoCount = i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::FIFO_COUNT_H, error); // higher 8 bits
+      if(*error == I2C_STATUS_SUCCESS)
+      {
+        fifoCount = (fifoCount << 8) |  i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::FIFO_COUNT_L, error); // assemble higher and lower bytes
+        return fifoCount;
+      }
+
+      return 0x00;
+    }
+
+    /**
+    * @brief This function gets the INT_ENABLE register value.
+    * @param error Result of the operation
+    * @retval uint8_t Enabled/Disabled sensor interrupts. Use Regbits_INT_ENABLE namespace as bitmask to check enabled interrupts.
+    */
+    uint8_t MPU6050::GetSensor_InterruptEnable(i2c_status_t* error)
+    {
+      return i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::INT_ENABLE, error);
+    }
+
+    /**
+    * @brief This function sets the sensor INT_ENABLE register with given value.
+    * @param enabledInterrupts Enabled/Disabled sensor interrupts. Use Regbits_INT_ENABLE namespace.
+    * @retval i2c_status_t
+    */
+    i2c_status_t MPU6050::SetSensor_InterruptEnable(uint8_t enabledInterrupts)
+    {
+      return i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::INT_ENABLE, enabledInterrupts);
+    }
+
+    /**
+    * @brief This function gets the sensor FIFO configuration. Use Regbits_FIFO_EN as bitmask to check which
+    *        samples enabled in the FIFO reading.
+    * @param error Result of the operation
+    * @retval uint8_t Sensor fifo configuration value, use Regbits_FIFO_EN to check fifo config.
+    */
+    uint8_t MPU6050::GetSensor_FIFO_Config(i2c_status_t* error)
+    {
+      return i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::FIFO_EN, error);
+    }
+
+    /**
+    * @brief This function sets the sensor FIFO configuration.
+    * @param fifoConfigVal FIFO config value, use Regbits_FIFO_EN as bitmask to configure.
+    * @retval i2c_status_t
+    */
+    i2c_status_t MPU6050::SetSensor_FIFO_Config(uint8_t fifoConfigVal)
+    {
+      return i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::FIFO_EN, fifoConfigVal);
+    }
+
+    /**
+    * @brief This function gets the sensor FIFO enable bit in USER_CTRL register.
+    * @param error Result of the operation
+    * @retval bool True if FIFO enabled
+    */
+    bool MPU6050::GetSensor_FIFO_Enable(i2c_status_t* error)
+    {
+      return i2c->ReadRegisterBit(MPU6050_ADDRESS, Sensor_Regs::USER_CTRL, Regbits_USER_CTRL::BIT_FIFO_EN, error);
+    }
+
+    /**
+    * @brief This function sets the sensor FIFO enable bit in USER_CTRL register.
+    * @param state State of the FIFO to be set. True if it will be enabled.
+    * @retval i2c_status_t
+    */
+    i2c_status_t MPU6050::SetSensor_FIFO_Enable(bool state)
+    {
+      return i2c->WriteRegisterBit(MPU6050_ADDRESS, Sensor_Regs::USER_CTRL, Regbits_USER_CTRL::BIT_FIFO_EN, state);
+    }
+
+    /**
+    * @brief This function resets the sensor FIFO.
+    * @param none
+    * @retval i2c_status_t
+    */
+    i2c_status_t MPU6050::Reset_Sensor_FIFO(void)
+    {
+      return i2c->WriteRegisterBit(MPU6050_ADDRESS, Sensor_Regs::USER_CTRL, Regbits_USER_CTRL::BIT_FIFO_RESET, true);
+    }
+
+    /**
+    * @brief This function gets the sensor interrput status (INT_STATUS) register.
+    * @param error Result of the operation
+    * @retval uint8_t Register value.
+    */
+    uint8_t MPU6050::GetSensor_InterruptStatus(i2c_status_t* error)
+    {
+      return i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::INT_STATUS, error);
+    }
+
+    /**
+    * @brief This function reads 1 byte from sensor FIFO data register.
+    * @param error Result of the operation.
+    * @retval uint8_t FIFO data.
+    */
+    uint8_t MPU6050::GetSensor_FIFO_Data(i2c_status_t* error)
+    {
+      return i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::FIFO_R_W, error);
+    }
+
+   /**
+    * @brief This function returns sensor interrupt pin config register value.
+    * @param error Result of the operation.
+    * @retval uint8_t Interrupt pin config register value.
+    */
+    uint8_t MPU6050::GetSensor_InterruptPinConfig(i2c_status_t* error)
+    {
+      return i2c->ReadRegister(MPU6050_ADDRESS, Sensor_Regs::INT_PIN_CFG, error);
+    }
+
+    /**
+    * @brief This function sets the sensor interrupt pin config register.
+    * @param intPinConfig interrput pin config value to set
+    * @retval i2c_status_t
+    */
+    i2c_status_t MPU6050::SetSensor_InterruptPinConfig(uint8_t intPinConfig)
+    {
+      return i2c->WriteRegister(MPU6050_ADDRESS, Sensor_Regs::INT_PIN_CFG, intPinConfig);
+    }
+
+} // namespace MPU6050_Driver

--- a/lib/mpu6050/mpu6050.h
+++ b/lib/mpu6050/mpu6050.h
@@ -1,0 +1,605 @@
+/**
+  ******************************************************************************
+  * @file    mpu6050.h
+  * @author  Ali Batuhan KINDAN
+  * @date    20.12.2020
+  * @brief   This file constains MPU6050 driver declarations.
+  *
+  * MIT License
+  *
+  * Copyright (c) 2022 Ali Batuhan KINDAN
+  * 
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  * 
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  * 
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+#ifndef MPU6050_H
+#define MPU6050_H
+
+#include "i2c_interface.h"
+
+namespace MPU6050_Driver {
+
+  /* TODO: Make a setter for device address. Use enum for 2 possible sensor address! */
+  #define AD0 1
+
+  /* MPU6050 I2C Device Address */
+  #define MPU6050_ADDRESS_AD0 0x68 // AD0 pin low
+  #define MPU6050_ADDRESS_AD1 0x69 // AD0 pin high
+
+  /* Define default MPU6050 address as 0x68 (AD0 pin low) */
+  #if AD0
+  #define MPU6050_ADDRESS MPU6050_ADDRESS_AD0
+  #else
+  #define MPU6050_ADDRESS MPU6050_ADDRESS_AD1
+  #endif
+
+  /* define sensor register type here to write it easily */
+  #define SensorConst static constexpr uint8_t
+  /* bit masks */
+  #define BIT_0 (1 << 0)
+  #define BIT_1 (1 << 1)
+  #define BIT_2 (1 << 2)
+  #define BIT_3 (1 << 3)
+  #define BIT_4 (1 << 4)
+  #define BIT_5 (1 << 5)
+  #define BIT_6 (1 << 6)
+  #define BIT_7 (1 << 7)
+
+  namespace Sensor_Regs {
+    SensorConst USER_CTRL = 0x6A;
+    SensorConst PWR_MGMT_1 = 0x6B;
+    SensorConst GYRO_CONFIG = 0x1B;
+    SensorConst ACCEL_CONFIG = 0x1C;
+    SensorConst INT_ENABLE = 0x38;
+    SensorConst INT_PIN_CFG = 0x37;
+    SensorConst INT_STATUS = 0x3A;
+
+    /* FIFO registers */
+    SensorConst FIFO_EN = 0x23;
+    SensorConst FIFO_COUNT_L = 0x73;
+    SensorConst FIFO_COUNT_H = 0x72;
+    SensorConst FIFO_R_W = 0x74;
+
+    /* Accelerometer read registers */
+    SensorConst ACCEL_X_OUT_L = 0x3C;
+    SensorConst ACCEL_X_OUT_H = 0x3B;
+    SensorConst ACCEL_Y_OUT_H = 0x3D;
+    SensorConst ACCEL_Y_OUT_L = 0x3E;
+    SensorConst ACCEL_Z_OUT_H = 0x3F;
+    SensorConst ACCEL_Z_OUT_L = 0x40;
+    /* Temperature read SensorConstisters */
+    SensorConst TEMP_OUT_H = 0x41;
+    SensorConst TEMP_OUT_L = 0x42;
+    /* Gyroscope read SensorConstisters */
+    SensorConst GYRO_X_OUT_H = 0x43;
+    SensorConst GYRO_X_OUT_L = 0x44;
+    SensorConst GYRO_Y_OUT_H = 0x45;
+    SensorConst GYRO_Y_OUT_L = 0x46;
+    SensorConst GYRO_Z_OUT_H = 0x47;
+    SensorConst GYRO_Z_OUT_L = 0x48;
+    /* Gyroscope offset SensorConstisters */
+    SensorConst XG_OFFS_USR_H = 0x13;
+    SensorConst XG_OFFS_USR_L = 0x14;
+    SensorConst YG_OFFS_USR_H = 0x15;
+    SensorConst YG_OFFS_USR_L = 0x16;
+    SensorConst ZG_OFFS_USR_H = 0x17;
+    SensorConst ZG_OFFS_USR_L = 0x18;
+    /* Accellerometer offset SensorConstisters */
+    SensorConst XA_OFFS_USR_H = 0x06;
+    SensorConst XA_OFFS_USR_L = 0x07;
+    SensorConst YA_OFFS_USR_H = 0x08;
+    SensorConst YA_OFFS_USR_L = 0x09;
+    SensorConst ZA_OFFS_USR_H = 0x0A;
+    SensorConst ZA_OFFS_USR_L = 0x0B;
+
+    SensorConst SMPRT_DIV = 0x19; // sample rate divider
+    SensorConst CONFIG = 0x1A;    // digital low passand extra sync configutation
+  };
+
+  namespace Regbits_USER_CTRL {
+    SensorConst BIT_SIG_CONF_RESET = BIT_0;
+    SensorConst BIT_I2C_MST_RESET = BIT_1;
+    SensorConst BIT_FIFO_RESET = BIT_2;
+    SensorConst BIT_I2C_IF_DIS = BIT_4;
+    SensorConst BIT_I2C_MST_EN = BIT_5;
+    SensorConst BIT_FIFO_EN = BIT_6;
+  }
+
+  namespace Regbits_INT_ENABLE {
+    SensorConst BIT_DATA_RDY_EN = BIT_0;
+    SensorConst BIT_I2C_MST_INT_EN = BIT_3;
+    SensorConst BIT_FIFO_OFLOW_EN = BIT_4;
+  }
+
+  namespace Regbits_PWR_MGMT_1 {
+    SensorConst BIT_CLKSEL_0 = BIT_0;
+    SensorConst BIT_CLKSEL_1 = BIT_1;
+    SensorConst BIT_CLKSEL_2 = BIT_2;
+    SensorConst BIT_TEMP_DIS = BIT_3;
+    SensorConst BIT_CYCLE = BIT_5;
+    SensorConst BIT_SLEEP = BIT_6;
+    SensorConst BIT_DEVICE_RESET = BIT_7;
+  };
+
+  namespace Regbits_FIFO_EN {
+    SensorConst BIT_SLV0_FIFO_EN = BIT_0;
+    SensorConst BIT_SLV1_FIFO_EN = BIT_1;
+    SensorConst BIT_SLV2_FIFO_EN = BIT_2;
+    SensorConst BIT_ACCEL_FIFO_EN = BIT_3;
+    SensorConst BIT_ZG_FIFO_EN = BIT_4;
+    SensorConst BIT_YG_FIFO_EN = BIT_5;
+    SensorConst BIT_XG_FIFO_EN = BIT_6;
+    SensorConst BIT_TEMP_FIFO_EN = BIT_7;
+  };
+
+  namespace Regbits_INT_PIN_CFG {
+    SensorConst BIT_I2C_BYPASS_EN = BIT_1;
+    SensorConst BIT_FSYNC_INT_EN = BIT_2;
+    SensorConst BIT_FSYNC_INT_LEVEL = BIT_3;
+    SensorConst BIT_INT_RD_CLEAR = BIT_4;
+    SensorConst BIT_LATCH_INT_EN = BIT_5;
+    SensorConst BIT_INT_OPEN = BIT_6;
+    SensorConst BIT_INT_LEVEL = BIT_7;
+  }
+
+  /* Gyroscope full scale ranges in degrees per second */
+  enum class Gyro_FS_t
+  {
+    FS_250_DPS = 0,
+    FS_500_DPS = 1,
+    FS_1000_DPS = 2,
+    FS_2000_DPS = 3
+  };
+
+  /* Accelerometer full scale ranges in G's */
+  enum class Accel_FS_t
+  {
+    FS_2G = 0,
+    FS_4G = 1,
+    FS_8G = 2,
+    FS_16G = 3
+  };
+
+  /* Digital low pass filter config bandwidth values in Hz*/
+  enum class DLPF_t 
+  {
+    BW_260Hz = 0,
+    BW_184Hz = 1,
+    BW_94Hz = 2,
+    BW_44Hz = 3,
+    BW_21Hz = 4,
+    BW_10Hz = 5,
+    BW_5Hz = 6,
+    RESERVED = 7
+  };
+
+  class MPU6050 
+  {
+  public:
+
+    /**
+    * @brief  Class constructor. In order to make the class communicate with sensor
+    * user should pass a valid I2C_Interface class instance!
+    * @param  comInterface I2C interface pointer
+    * @retval none
+    */
+    MPU6050(I2C_Interface* comInterface);
+
+    /**
+    * @brief  This method wakes up the sensor and configures the accelerometer and
+    * gyroscope full scale renges with given parameters. It returns the result of
+    * the process.
+    * @param  gyroScale Gyroscope scale value to be set
+    * @param  accelScale Accelerometer scale value to be set
+    * @retval i2c_status_t Success rate
+    */
+    i2c_status_t InitializeSensor(
+        Gyro_FS_t gyroScale = Gyro_FS_t::FS_250_DPS,
+        Accel_FS_t accelScale = Accel_FS_t::FS_2G);
+
+    /**
+    * @brief  This method wakes the sensor up by cleraing the REG_PWR_MGMT_1
+    * BIT_SLEEP. Power management 1 sensors default values is 0x40 so it will
+    * be in sleep mode when it's powered up.
+    * @param  none
+    * @retval i2c_status_t
+    */
+    i2c_status_t WakeUpSensor(void);
+
+    /**
+    * @brief  This method resets the sensor by simply setting the REG_PWR_MGMT_1
+    * Device_Reset bit. After the sensor reset this bit will be cleared automatically.
+    * @param  none
+    * @retval i2c_status_t
+    */
+    i2c_status_t ResetSensor(void);
+
+    /**
+    * @brief  This method used for configuring the gyroscope full scale range.
+    * Check gyro_full_scale_range_t for available scales.
+    * @param  gyroScale Gyroscope scale value to be set
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetGyroFullScale(Gyro_FS_t gyroScale);
+
+    /**
+    * @brief  This method used for getting the gyroscope full scale range.
+    * Check gyro_full_scale_range_t for available scales. It basically reads the
+    * Gyro configuration register and returns the full scale range.
+    * @param  error Result of the sensor reading process
+    * @retval gyro_full_scale_range_t
+    */
+    Gyro_FS_t GetGyroFullScale(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for getting the latest gyroscope X axis RAW value from
+    * the sensor. Make sure that sensor is not in sleeping mode and gyroscope full
+    * scale range is set to desired range before reading the values.
+    * @param  error Error state of process
+    * @retval int16_t X axis RAW gyroscope value
+    */
+    int16_t GetGyro_X_Raw(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for getting the latest gyroscope Y axis RAW value from
+    * the sensor. Make sure that sensor is not in sleeping mode and gyroscope full
+    * scale range is set to desired range before reading the values.
+    * @param  error Error state of process
+    * @retval int16_t Y axis RAW gyroscope value
+    */
+    int16_t GetGyro_Y_Raw(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for getting the latest gyroscope Z axis RAW value from
+    * the sensor. Make sure that sensor is not in sleeping mode and gyroscope full
+    * scale range is set to desired range before reading the values.
+    * @param  error Error state of process
+    * @retval int16_t Z axis RAW gyroscope value
+    */
+    int16_t GetGyro_Z_Raw(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for configuring the accelerometer full scale range.
+    * Check accel_full_scale_range_t for available scales.
+    * @param  accelScale Accelerometer scale value to be set
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetAccelFullScale(Accel_FS_t accelScale);
+
+    /**
+    * @brief  This method used for getting the acceleromteter full scale range.
+    * Check accel_full_scale_range_t for available scales. It basically reads the
+    * Accel configuration register and returns the full scale range.
+    * @param  error Result of the sensor reading process
+    * @retval accel_full_scale_range_t
+    */
+    Accel_FS_t GetAccelFullScale(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for getting the latest accelerometer X axis RAW value from
+    * the sensor. Make sure that sensor is not in sleeping mode and accelerometer full
+    * scale range is set to desired range, before reading the values.
+    * @param  error Error state of process
+    * @retval int16_t X axis RAW acceleration value
+    */
+    int16_t GetAccel_X_Raw(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for getting the latest accelerometer Y axis RAW value from
+    * the sensor. Make sure that sensor is not in sleeping mode and accelerometer full
+    * scale range is set to desired range, before reading the values.
+    * @param  error Error state of process
+    * @retval int16_t Y axis RAW acceleration value
+    */
+    int16_t GetAccel_Y_Raw(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for getting the latest accelerometer Z axis RAW value from
+    * the sensor. Make sure that sensor is not in sleeping mode and accelerometer full
+    * scale range is set to desired range, before reading the values.
+    * @param  error Error state of process
+    * @retval int16_t Z axis RAW acceleration value
+    */
+    int16_t GetAccel_Z_Raw(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for getting the latest temperature value from the sensor.
+    * scale range is set to desired range, before reading the values.
+    * @param  error Error state of process
+    * @retval float Temperature in celcius-degrees
+    */
+    float GetTemperature_Celcius(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for setting the gyroscope X axis offset value. Offset is
+    * using in the sensor calibration routine.
+    * @param offset
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetGyro_X_Offset(int16_t offset);
+
+    /**
+    * @brief  This method used for getting the gyroscope X axis offset value.
+    * @param error Result of the operation
+    * @retval int16_t
+    */
+    int16_t GetGyro_X_Offset(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for setting the gyroscope Y axis offset value. Offset is
+    * using in the sensor calibration routine.
+    * @param offset
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetGyro_Y_Offset(int16_t offset);
+
+    /**
+    * @brief  This method used for getting the gyroscope Y axis offset value.
+    * @param error Result of the operation
+    * @retval int16_t
+    */
+    int16_t GetGyro_Y_Offset(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for setting the gyroscope Z axis offset value. Offset is
+    * using in the sensor calibration routine.
+    * @param offset
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetGyro_Z_Offset(int16_t offset);
+
+    /**
+    * @brief  This method used for getting the gyroscope Z axis offset value.
+    * @param error Result of the operation
+    * @retval int16_t
+    */
+    int16_t GetGyro_Z_Offset(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for calibrating the gyroscope registers to given target values.
+    * @param targetX target value for gyroscope X axis register
+    * @param targetY target value for gyroscope Y axis register
+    * @param targetZ target value for gyroscope Z axis register
+    * @retval i2c_status_t
+    */
+    i2c_status_t Calibrate_Gyro_Registers(int16_t targetX = 0, int16_t targetY = 0, int16_t targetZ = 0);
+
+    /**
+    * @brief  This method returns the DPS (Degree Per Second) coversion value depending on
+    * the gyroscope full scale range. DPS value is used to convert raw sensor value to angular
+    * velocity for orientation related calculations.
+    * @param gyroRange Configured gyro full scale range
+    * @retval float
+    */
+    float GetGyro_DPS_Constant(Gyro_FS_t gyroRange);
+
+    /**
+    * @brief  This method used for setting the accelerometer X axis offset value. Offset is
+    * using in the sensor calibration routine.
+    * @param offset
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetAccel_X_Offset(int16_t offset);
+
+    /**
+    * @brief  This method used for getting the accelerometer X axis offset value.
+    * @param error Result of the operation
+    * @retval int16_t
+    */
+    int16_t GetAccel_X_Offset(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for setting the accelerometer Y axis offset value. Offset is
+    * using in the sensor calibration routine.
+    * @param offset
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetAccel_Y_Offset(int16_t offset);
+
+    /**
+    * @brief  This method used for getting the accelerometer Y axis offset value.
+    * @param error Result of the operation
+    * @retval int16_t
+    */
+    int16_t GetAccel_Y_Offset(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for setting the accelerometer Z axis offset value. Offset is
+    * using in the sensor calibration routine.
+    * @param offset
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetAccel_Z_Offset(int16_t offset);
+
+    /**
+    * @brief  This method used for getting the accelerometer Z axis offset value.
+    * @param error Result of the operation
+    * @retval int16_t
+    */
+    int16_t GetAccel_Z_Offset(i2c_status_t* error);
+
+    /**
+    * @brief  This method used for calibrating the accelerometer registers to given target values.
+    * @param targetX target value for accelerometer X axis register in MG so 1.0f means 1G
+    * @param targetY target value for accelerometer Y axis register in MG
+    * @param targetZ target value for accelerometer Z axis register in MG
+    * @retval i2c_status_t
+    */
+    i2c_status_t Calibrate_Accel_Registers(float targetX_MG = 0.0f, float targetY_MG = 0.0f, float targetZ_MG = 1.0f);
+
+    /**
+    * @brief  This method returns the MG (Gravity) coversion value depending on
+    * the accelerometer full scale range. MG value is used to convert raw sensor value to Gravity
+    * for acceleration related calculations.
+    * @param accelRange Configured accelerometer full scale range
+    * @retval float
+    */
+    float GetAccel_MG_Constant(Accel_FS_t accelRange);
+
+    /**
+    * @brief This function sets the gyroscope sample rate divider. Once the sample rate divider set, actual sample rate
+    *        can be found with this formula:
+    *        Actual sample rate = Gyroscope Output Rate / (1 + sampleRate)
+    *        Keep in mind that Gyroscope Output Rate = 8kHz when the DLPF (digital low pass filter) is disabled
+    *        (DLPF_CFG = 0 or 7), and 1kHz when the DLPF is enabled. Accel sample rate is constantly 1 kHz.
+    * @param sampleRate Gyroscope sample rate divider.     
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetGyro_SampleRateDivider(uint8_t sampleRate);
+
+    /**
+    * @brief This function gets the gyroscope sample rate divider.
+    *        Actual sample rate = Gyroscope Output Rate / (1 + sampleRate)
+    *        Keep in mind that Gyroscope Output Rate = 8kHz when the DLPF (digital low pass filter) is disabled
+    *        (DLPF_CFG = 0 or 7), and 1kHz when the DLPF is enabled. Accel sample rate is constantly 1 kHz.
+    * @param error Result of the operation
+    * @retval uint8_t
+    */
+    uint8_t GetGyro_SampleRateDivider(i2c_status_t* error);
+
+    /**
+    * @brief This function sets the sensor digital low pass filter values. Tighter bandwitdh configs will
+    *        generate more delay on the sensor outputs (check sensor datasheet). Keep in mind that default
+    *        Gyroscope sample rate is 8 kHz but if we set DLPF config different than 0 it will be 1 kHz by default
+    *        unless if we make an extra configuration to Sample Rate Divider.
+    * @param dlpfConfig Digital low pass filter configuration value
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetSensor_DLPF_Config(DLPF_t dlpfConfig);
+
+    /**
+    * @brief This function gets the current sensor digital low pass filter configuration.
+    * @param error Result of the operation
+    * @retval dlpf_config_t
+    */
+    DLPF_t GetSensor_DLPF_Config(i2c_status_t* error);
+
+    /**
+    * @brief This function gets the current sensor sample rate. In order to do this, method
+    *        reads Sample Rate Divider (0x19) and DLPF Config (0x1A) registers.
+    * @param error Result of the operation
+    * @retval float Current sample rate in Hz
+    */
+    float GetSensor_CurrentSampleRate_Hz (i2c_status_t* error);
+
+    /**
+    * @brief This function gets the number of bytes written in the sensor FIFO buffers.
+    * @param error Result of the operation
+    * @retval uint16_t Number of samples in the FIFO buffer in bytes
+    */
+    uint16_t GetSensor_FIFOCount(i2c_status_t* error);
+
+    /**
+    * @brief This function gets the INT_ENABLE register value.
+    * @param error Result of the operation
+    * @retval uint8_t Enabled/Disabled sensor interrupts. Use Regbits_INT_ENABLE namespace as bitmask to check enabled interrupts.
+    */
+    uint8_t GetSensor_InterruptEnable(i2c_status_t* error);
+
+    /**
+    * @brief This function sets the sensor INT_ENABLE register with given value.
+    * @param enabledInterrupts Enabled/Disabled sensor interrupts. Use Regbits_INT_ENABLE namespace.
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetSensor_InterruptEnable(uint8_t enabledInterrupts);
+
+    /**
+    * @brief This function gets the sensor FIFO configuration. Use Regbits_FIFO_EN as bitmask to check which
+    *        samples enabled in the FIFO reading.
+    * @param error Result of the operation
+    * @retval uint8_t Sensor fifo configuration value, use Regbits_FIFO_EN to check fifo config.
+    */
+    uint8_t GetSensor_FIFO_Config(i2c_status_t* error);
+
+    /**
+    * @brief This function sets the sensor FIFO configuration.
+    * @param fifoConfigVal FIFO config value, use Regbits_FIFO_EN as bitmask to configure.
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetSensor_FIFO_Config(uint8_t fifoConfigVal);
+
+    /**
+    * @brief This function gets the sensor FIFO enable bit in USER_CTRL register.
+    * @param error Result of the operation
+    * @retval bool True if FIFO enabled
+    */
+    bool GetSensor_FIFO_Enable(i2c_status_t* error);
+
+    /**
+    * @brief This function sets the sensor FIFO enable bit in USER_CTRL register.
+    * @param state State of the FIFO to be set. True if it will be enabled.
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetSensor_FIFO_Enable(bool state);
+
+    /**
+    * @brief This function resets the sensor FIFO.
+    * @param none
+    * @retval i2c_status_t
+    */
+    i2c_status_t Reset_Sensor_FIFO(void);
+
+    /**
+    * @brief This function gets the sensor interrput status (INT_STATUS) register.
+    * @param error Result of the operation
+    * @retval uint8_t Register value.
+    */
+    uint8_t GetSensor_InterruptStatus(i2c_status_t* error);
+
+    /**
+    * @brief This function reads 1 byte from sensor FIFO data register.
+    * @param error Result of the operation.
+    * @retval uint8_t FIFO data.
+    */
+    uint8_t GetSensor_FIFO_Data(i2c_status_t* error);
+
+    /**
+    * @brief This function returns sensor interrupt pin config register value.
+    * @param error Result of the operation.
+    * @retval uint8_t Interrupt pin config register value.
+    */
+    uint8_t GetSensor_InterruptPinConfig(i2c_status_t* error);
+
+    /**
+    * @brief This function sets the sensor interrupt pin config register.
+    * @param intPinConfig interrput pin config value to set
+    * @retval i2c_status_t
+    */
+    i2c_status_t SetSensor_InterruptPinConfig(uint8_t intPinConfig);
+
+
+  private:
+    I2C_Interface* i2c = nullptr;
+    /* DPS constant to convert raw register value to the degree per seconds (angular velocity).
+    * The index of the values are adjusted to have corresponding values with the gyro_full_scale_range_t
+    * enum. So, we can just get the DPS value by "dpsConstantArr[GYRO_SCALE_250]"" for GYRO_SCALE_250. */
+    const float dpsConstantArr[4] = {250.0f / 32767.0f, 500.0f / 32767.0f, 1000.0f / 32767.0f, 2000.0f / 32767.0f};
+
+    /* MG constant to convert raw register value to gravity (9.81 m/s2). The index of the values are
+    * adjusted to have corresponding values with the accel_full_scale_range_t enum. So, we can just get
+    * the MG value by "mgConstantArr[ACCEL_SCALE_2G]"" for ACCEL_SCALE_2G. */
+    const float mgCostantArr[4] = {2.0f / 32767.0f, 4.0f / 32767.0f, 8.0f / 32767.0f, 16.0f / 32767.0f};
+
+    /* Gyro offset register constant to compensate 1 DPS (degree per second) offset.
+  * Check sensor datasheet for more info about the offset procedure! */
+    const float gyro_offset_1dps = 32.8f;
+  };
+
+} // namespace MPU6050_Driver
+
+#endif /* include guard */

--- a/lib/mpu6050/smbus_i2c_if.cpp
+++ b/lib/mpu6050/smbus_i2c_if.cpp
@@ -1,0 +1,125 @@
+/**
+  ******************************************************************************
+  * @file    smbus_i2c_if.cpp
+  * @author  Adam Englebright
+  * @author  Ali Batuhan KINDAN
+  * @date    28.02.2024
+  * @brief   This file constains the imlementation I2C interface using the
+  * kernel SMBus interface. Based on batu92k's example code for implementing
+  * the I2C interface using the bcm2835 library:
+  * https://github.com/batu92k/MPU6050-Sensor-Library-Cpp/blob/master/examples/RPi_4/bcm2835/bcm2835_i2c_if.cpp
+  *
+  * MIT License
+  *
+  * Copyright (c) 2022 Ali Batuhan KINDAN
+  * Copyright (c) 2024 Adam Englebright
+  * 
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  * 
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  * 
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+#include "smbus_i2c_if.h"
+#include <cstdint>
+#include <iostream>
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+extern "C" {
+#include <linux/i2c-dev.h>
+#include <i2c/smbus.h>
+}
+
+/**
+  * @brief  I2C peripheral initialization method.
+  * @param  slaveAddress adress of the device that will be communicated
+  * @retval i2c_status_t
+  */
+i2c_status_t SMBUS_I2C_IF::Init_I2C(uint8_t slaveAddress)
+{
+	/* Initalize I2C controller using device file and corresponding
+	 * file descriptor. */
+	fd = open("/dev/i2c-0", O_RDWR); // Open divice file and get file descriptor
+	if (fd < 0) { // Catch errors
+		std::cout << "ERROR: smbus_i2c_if.cpp: SMBUS_I2C_IF::Init_I2C(): Unable to open /dev/i2c-0. Error code " << fd << std::endl;
+		exit(fd);
+	}
+
+	int status;
+	status = ioctl(fd, I2C_SLAVE, slaveAddress); // Set up the peripheral slave address
+	if (status < 0) { // Catch errors
+		std::cout << "ERROR: smbus_i2c_if.cpp: SMBUS_I2C_IF::Init_I2C(): Could not set up I2C bus with " << slaveAddress << " slave address. Error code " << status << std::endl;
+		exit(status);
+	}
+
+	return I2C_STATUS_SUCCESS;
+}
+
+/**
+  * @brief  This method will be used for reading the data of the given register from
+  * the slave with given address.
+  * @param  slaveAddress Slave chip I2C bus address (not used in this RTEP5 implementation, but not removed to avoid needing a large rewrite of the library)
+  * @param  regAddress Register address to be read
+  * @param  status Pointer for operation status
+  * @retval uint8_t Read register value
+  */
+uint8_t SMBUS_I2C_IF::ReadRegister(uint8_t slaveAddress, uint8_t regAddress, i2c_status_t *status)
+{
+	int32_t data; // Data returned from i2c_smbus_read_byte_data() is a signed 32 bit integer.
+	              // Negative for error, else positive with 8 bit value for byte data (i.e. 0-255).
+	data = i2c_smbus_read_byte_data(fd, regAddress); // Read a byte
+	if (data < 0) { // Catch errors
+		std::cout << "ERROR: smbus_i2c_if.cpp: SMBUS_I2C_IF::ReadRegister(): Could not read a byte at register address " << regAddress << ". Error code " << data << std::endl;
+		*status = I2C_STATUS_ERROR;
+		return 0;
+	}
+
+	*status = I2C_STATUS_SUCCESS;
+	return (uint8_t)data;
+}
+
+/**
+  * @brief  This method will be used for writing gven data to the given register of the slave device 
+  * with the given address.
+  * @param  slaveAddress Slave chip I2C bus address (not used in this RTEP5 implementation, but not removed to avoid needing a large rewrite of the library)
+  * @param  regAddress Register address that the data to be written
+  * @param  data Data to be written
+  * @retval i2c_status_t
+  */
+i2c_status_t SMBUS_I2C_IF::WriteRegister(uint8_t slaveAddress, uint8_t regAddress, uint8_t data)
+{
+	int32_t errno; // Returned value from i2c_smbus_write_byte_data() is a signed 32 bit integer.
+	               // Negative for error, else zero.
+	errno = i2c_smbus_write_byte_data(fd, regAddress, data); // Write a byte
+	if (errno < 0) { // Catch errors
+		std::cout << "ERROR: smbus_i2c_if.cpp: SMBUS_I2C_IF::WriteRegister(): Could not write a byte to register address " << regAddress << ". Error code " << errno << std::endl;
+		return I2C_STATUS_ERROR;
+	}
+
+	return I2C_STATUS_SUCCESS;
+}
+
+/**
+  * @brief  Class destructor.
+  * @param  none
+  * @retval none
+  */
+SMBUS_I2C_IF::~SMBUS_I2C_IF()
+{
+        /* Close device file. */
+	close(fd);
+}

--- a/lib/mpu6050/smbus_i2c_if.h
+++ b/lib/mpu6050/smbus_i2c_if.h
@@ -1,0 +1,86 @@
+/**
+  ******************************************************************************
+  * @file    smbus_i2c_if.h
+  * @author  Adam Englebright
+  * @author  Ali Batuhan KINDAN
+  * @date    28.02.2024
+  * @brief   This file constains the definition I2C interface using the
+  * kernel SMBus interface. Based on batu92k's example code for defining
+  * the I2C interface using the bcm2835 library:
+  * https://github.com/batu92k/MPU6050-Sensor-Library-Cpp/blob/master/examples/RPi_4/bcm2835/bcm2835_i2c_if.h
+  *
+  * MIT License
+  *
+  * Copyright (c) 2022 Ali Batuhan KINDAN
+  * Copyright (c) 2024 Adam Englebright
+  * 
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  * 
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  * 
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+
+#include "i2c_interface.h"
+
+#ifndef SMBUS_I2C_IF_H
+#define SMBUS_I2C_IF_H
+
+/* I2C interface for BCM2835 library. */
+class SMBUS_I2C_IF : public I2C_Interface
+{
+public:
+/**
+  * @brief  I2C peripheral initialization method.
+  * @param  slaveAddress adress of the device that will be communicated
+  * @retval i2c_status_t
+  */
+  i2c_status_t Init_I2C(uint8_t slaveAddress) override;
+
+/**
+  * @brief  This method will be used for reading the data of the given register from
+  * the slave with given address.
+  * @param  slaveAddress Slave chip I2C bus address (not used in this RTEP5 implementation, but not removed to avoid needing a large rewrite of the library)
+  * @param  regAddress Register address to be read
+  * @param  status Pointer for operation status
+  * @retval uint8_t Read register value
+  */
+  uint8_t ReadRegister(uint8_t slaveAddress, uint8_t regAddress, i2c_status_t *status) override;
+
+/**
+  * @brief  This method will be used for writing gven data to the given register of the slave device 
+  * with the given address.
+  * @param  slaveAddress Slave chip I2C bus address (not used in this RTEP5 implementation, but not removed to avoid needing a large rewrite of the library)
+  * @param  regAddress Register address that the data to be written
+  * @param  data Data to be written
+  * @retval i2c_status_t
+  */
+  i2c_status_t WriteRegister(uint8_t slaveAddress, uint8_t regAddress, uint8_t data) override;
+
+/**
+  * @brief  Class destructor.
+  * @param  none
+  * @retval none
+  */  
+  ~SMBUS_I2C_IF() override;
+
+private:
+/**
+  * @brief  File descriptor for /dev/i2c-0, used to send data over I2C.
+  */
+  int fd;
+};
+
+#endif


### PR DESCRIPTION
Initial implementation for control of the MPU6050, mostly using code from batu92k's [library](https://github.com/batu92k/MPU6050-Sensor-Library-Cpp) for this purpose. Implemented the I2C interface using the kernel SMBus method. This may need more work in the future to implement callbacks caused by the MPU6050's interrupt pin (which can be configured using this library as is).