### PR TITLE
Improve pointer safety in MPU6050 library to avoid potential through-null-pointer assignment

### DIFF
--- a/lib/mpu6050/i2c_interface.h
+++ b/lib/mpu6050/i2c_interface.h
@@ -97,7 +97,7 @@ public:
   * @param  status Pointer for operation status
   * @retval uint8_t Read register value
   */
-  virtual uint8_t ReadRegister(uint8_t slaveAddress, uint8_t regAddress, i2c_status_t *status) = 0;
+  virtual uint8_t ReadRegister(uint8_t slaveAddress, uint8_t regAddress, i2c_status_t *status = nullptr) = 0;
 
   /**
   * @brief  This method will be used for writing given data to the given register of the slave device 

--- a/lib/mpu6050/smbus_i2c_if.cpp
+++ b/lib/mpu6050/smbus_i2c_if.cpp
@@ -88,7 +88,7 @@ uint8_t SMBUS_I2C_IF::ReadRegister(uint8_t slaveAddress, uint8_t regAddress, i2c
 		return 0;
 	}
 
-	*status = I2C_STATUS_SUCCESS;
+	status && (*status = I2C_STATUS_SUCCESS);
 	return (uint8_t)data;
 }
 

--- a/lib/mpu6050/smbus_i2c_if.h
+++ b/lib/mpu6050/smbus_i2c_if.h
@@ -57,7 +57,7 @@ public:
   * @param  status Pointer for operation status
   * @retval uint8_t Read register value
   */
-  uint8_t ReadRegister(uint8_t slaveAddress, uint8_t regAddress, i2c_status_t *status) override;
+  uint8_t ReadRegister(uint8_t slaveAddress, uint8_t regAddress, i2c_status_t *status = nullptr) override;
 
 /**
   * @brief  This method will be used for writing gven data to the given register of the slave device 


### PR DESCRIPTION
Add some code that ensures no through-null-pointer assignment can happen in the SMBus I2C interface implementation.